### PR TITLE
dev

### DIFF
--- a/croo/cromwell_metadata.py
+++ b/croo/cromwell_metadata.py
@@ -88,12 +88,20 @@ class CromwellMetadata(object):
                         parent_wf_shard_idx=(shard_idx,))
                     continue
 
-                in_files = [
-                    (k, v) for k, v in c['inputs'].items()
-                    if isinstance(v, str) and CaperURI(v).is_valid_uri()]
-                out_files = [
-                    (k, v) for k, v in c['outputs'].items()
-                    if isinstance(v, str) and CaperURI(v).is_valid_uri()]
+                if 'inputs' in c:
+                    in_files = [
+                        (k, v) for k, v in c['inputs'].items()
+                        if isinstance(v, str) and CaperURI(v).is_valid_uri()]
+                else:
+                    in_files = []
+
+                if 'outputs' in c:
+                    out_files = [
+                        (k, v) for k, v in c['outputs'].items()
+                        if isinstance(v, str) and CaperURI(v).is_valid_uri()]
+                else:
+                    out_files = []
+
                 t = {
                     'task_name': parent_wf_name + wf_name + '.' + task_alias,
                     'shard_idx': parent_wf_shard_idx + (shard_idx,),

--- a/croo/croo.py
+++ b/croo/croo.py
@@ -36,6 +36,14 @@ class Croo(object):
             f = CaperURI(metadata_json).get_local_file()
             with open(f, 'r') as fp:
                 self._metadata = json.loads(fp.read())
+            if isinstance(self._metadata, list):
+                if len(self._metadata) > 1:
+                    print('[Croo] Warning: multiple metadata JSON objects '
+                          'found in metadata JSON file. Taking the first '
+                          'one...')
+                elif len(self._metadata) == 0:
+                    raise Exception('metadata JSON file is empty')
+                self._metadata = self._metadata[0]
         self._out_dir = out_dir
         self._cm = CromwellMetadata(self._metadata)
         self._use_rel_path_in_link = use_rel_path_in_link


### PR DESCRIPTION
* bug fix for 'outputs' key error
* for the contents in `metadata.json` file, Croo can take in a list of Python dicts `[ { } ]` but only the first `[0]` dict object `{ }` will be taken. Others will be ignored.