### PR TITLE
replace CaperURI with AutoURI

### DIFF
--- a/croo/cromwell_metadata.py
+++ b/croo/cromwell_metadata.py
@@ -9,7 +9,7 @@ Author:
 import re
 import json
 import caper
-from caper.caper_uri import CaperURI
+from autouri import AutoURI
 from collections import OrderedDict, namedtuple
 from .dag import DAG
 
@@ -61,7 +61,7 @@ def find_files_in_dict(d):
         elif isinstance(v, str):
             maybe_files.append((v, (-1,)))
         for f, shard_idx in maybe_files:
-            if CaperURI(f).is_valid_uri():
+            if AutoURI(f).is_valid:
                 files.append((k, f, shard_idx))
     return files
 

--- a/croo/croo.py
+++ b/croo/croo.py
@@ -19,7 +19,7 @@ from .cromwell_metadata import CromwellMetadata
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s|%(name)s|%(levelname)s| %(message)s')
-logger = logging.getLogger('croo')
+logger = logging.getLogger(__name__)
 
 
 class Croo(object):

--- a/croo/croo.py
+++ b/croo/croo.py
@@ -117,6 +117,13 @@ class Croo(object):
             workflow_id=self._cm.get_workflow_id(),
             dag=self._task_graph,
             task_graph_template=self._task_graph_template,
+            public_gcs=self._public_gcs,
+            gcp_private_key=self._gcp_private_key,
+            use_presigned_url_gcs=self._use_presigned_url_gcs,
+            use_presigned_url_s3=self._use_presigned_url_s3,
+            duration_presigned_url_s3 = self._duration_presigned_url_s3,
+            duration_presigned_url_gcs = self._duration_presigned_url_gcs,
+            map_path_to_url=self._map_path_to_url,
             ucsc_genome_db=self._ucsc_genome_db,
             ucsc_genome_pos=self._ucsc_genome_pos)
 

--- a/croo/croo_args.py
+++ b/croo/croo_args.py
@@ -13,7 +13,6 @@ from autouri import S3URI, GCSURI
 from autouri import logger as autouri_logger
 
 
-
 __version__ = '0.3.5'
 
 def parse_croo_arguments():
@@ -37,9 +36,6 @@ def parse_croo_arguments():
         'Original output files will be kept in Cromwell\'s output '
         'directory. '
         '"copy" makes copies of Cromwell\'s original outputs')
-    p.add_argument(
-        '--no-graph', action='store_true',
-        help='No task graph.')
     p.add_argument(
         '--ucsc-genome-db',
         help='UCSC genome browser\'s "db=" parameter. '

--- a/croo/croo_args.py
+++ b/croo/croo_args.py
@@ -8,9 +8,8 @@ Author:
 
 import argparse
 import sys
-from caper.caper_uri import (
-    MAX_DURATION_SEC_PRESIGNED_URL_S3,
-    MAX_DURATION_SEC_PRESIGNED_URL_GCS)
+import logging
+from autouri import AutoURI, S3URI, GCSURI
 
 
 __version__ = '0.3.5'
@@ -64,11 +63,11 @@ def parse_croo_arguments():
              'presigned URLs on files on gs://.')
     p.add_argument(
         '--duration-presigned-url-s3', type=int,
-        default=MAX_DURATION_SEC_PRESIGNED_URL_S3,
+        default=S3URI.DURATION_PRESIGNED_URL,
         help='Duration for presigned URLs for files on s3:// in seconds. ')
     p.add_argument(
         '--duration-presigned-url-gcs', type=int,
-        default=MAX_DURATION_SEC_PRESIGNED_URL_GCS,
+        default=GCSURI.DURATION_PRESIGNED_URL,
         help='Duration for presigned URLs for files on gs:// in seconds. ')
     p.add_argument(
         '--tsv-mapping-path-to-url',
@@ -87,16 +86,19 @@ def parse_croo_arguments():
              'stored here. You can clean it up but will lose all cached files '
              'so that remote files will be re-downloaded.')
     p.add_argument(
-        '--use-gsutil-over-aws-s3', action='store_true',
-        help='Use gsutil instead of aws s3 CLI even for S3 buckets.')
-    p.add_argument(
-        '--http-user',
-        help='Username to download data from private URLs')
-    p.add_argument(
-        '--http-password',
-        help='Password to download data from private URLs')
+        '--use-gsutil-for-s3', action='store_true',
+        help='Use gsutil for direct tranfer between GCS and S3 buckets. '
+             'Make sure that you have "gsutil" installed and configured '
+             'to have access to credentials for GCS and S3 '
+             '(e.g. ~/.boto or ~/.aws/credientials)')
     p.add_argument('-v', '--version', action='store_true',
                    help='Show version')
+
+    group_log_level = p.add_mutually_exclusive_group()
+    group_log_level.add_argument('-V', '--verbose', action='store_true',
+                   help='Prints all logs >= INFO level')
+    group_log_level.add_argument('-d', '--debug', action='store_true',
+                   help='Prints all logs >= DEBUG level')
 
     if '-v' in sys.argv or '--version' in sys.argv:
         print(__version__)

--- a/croo/croo_args.py
+++ b/croo/croo_args.py
@@ -194,11 +194,12 @@ def init_autouri(args):
     if args['tsv_mapping_path_to_url'] is not None:
         mapping_path_to_url = {}
         f = os.path.expanduser(args['tsv_mapping_path_to_url'])
-        with open(f, 'r') as fp:
-            lines = fp.read().strip('\n').split('\n')
-            for line in lines:
-                k, v = line.split('\t')
-                mapping_path_to_url[k] = v
+import csv
+...
+        with open(f, newline="") as fp:
+            reader = csv.reader(fp, delimiter="\t")
+            for line in reader:
+                mapping_path_to_url[line[0]] = line[1]
         args['mapping_path_to_url'] = mapping_path_to_url
     else:
         args['mapping_path_to_url'] = None

--- a/croo/croo_args.py
+++ b/croo/croo_args.py
@@ -7,6 +7,7 @@ Author:
 """
 
 import argparse
+import csv
 import os
 import sys
 from autouri import S3URI, GCSURI
@@ -194,10 +195,8 @@ def init_autouri(args):
     if args['tsv_mapping_path_to_url'] is not None:
         mapping_path_to_url = {}
         f = os.path.expanduser(args['tsv_mapping_path_to_url'])
-import csv
-...
-        with open(f, newline="") as fp:
-            reader = csv.reader(fp, delimiter="\t")
+        with open(f, newline='') as fp:
+            reader = csv.reader(fp, delimiter='\t')
             for line in reader:
                 mapping_path_to_url[line[0]] = line[1]
         args['mapping_path_to_url'] = mapping_path_to_url

--- a/croo/croo_args.py
+++ b/croo/croo_args.py
@@ -153,9 +153,7 @@ def check_args(args):
     elif args['tmp_dir'].startswith(('gs://', 's3://')):
         raise ValueError('Cloud URI is not allowed for --tmp-dir')
 
-    if args['out_dir'] is None:
-        raise ValueError('--out-dir is not valid.')
-    elif args['out_dir'].startswith(('http://', 'https://')):
+    if args['out_dir'].startswith(('http://', 'https://')):
         raise ValueError('URL is not allowed for --out-dir')
 
 

--- a/croo/croo_args.py
+++ b/croo/croo_args.py
@@ -14,7 +14,7 @@ from autouri import S3URI, GCSURI
 from autouri import logger as autouri_logger
 
 
-__version__ = '0.3.5'
+__version__ = '0.4.0'
 
 def parse_croo_arguments():
     """Argument parser for Cromwell Output Organizer (COO)

--- a/croo/croo_args.py
+++ b/croo/croo_args.py
@@ -104,7 +104,7 @@ def parse_croo_arguments():
     group_log_level = p.add_mutually_exclusive_group()
     group_log_level.add_argument('-V', '--verbose', action='store_true',
                    help='Prints all logs >= INFO level')
-    group_log_level.add_argument('-d', '--debug', action='store_true',
+    group_log_level.add_argument('-D', '--debug', action='store_true',
                    help='Prints all logs >= DEBUG level')
 
     if '-v' in sys.argv or '--version' in sys.argv:

--- a/croo/croo_html_report.py
+++ b/croo/croo_html_report.py
@@ -9,7 +9,7 @@ import os
 from .croo_html_report_tracks import CrooHtmlReportUCSCTracks
 from .croo_html_report_file_table import CrooHtmlReportFileTable
 from .croo_html_report_task_graph import CrooHtmlReportTaskGraph
-from caper.caper_uri import CaperURI
+from autouri import AutoURI
 
 
 class CrooHtmlReport(object):
@@ -79,5 +79,5 @@ jquery.min.js"></script>
             self._out_dir,
             CrooHtmlReport.REPORT_HTML.format(
                 workflow_id=self._workflow_id))
-        CaperURI(uri_report).write_str_to_file(html)
+        AutoURI(uri_report).write(html)
         return html

--- a/croo/croo_html_report.py
+++ b/croo/croo_html_report.py
@@ -31,13 +31,32 @@ jquery.min.js"></script>
 
     def __init__(self, out_dir, workflow_id, dag,
                  task_graph_template=None,
+                 public_gcs=None,
+                 gcp_private_key=None,
+                 use_presigned_url_gcs=False,
+                 use_presigned_url_s3=False,
+                 duration_presigned_url_s3=None,
+                 duration_presigned_url_gcs=None,
+                 map_path_to_url=None,
                  ucsc_genome_db=None,
                  ucsc_genome_pos=None):
         self._out_dir = out_dir
         self._workflow_id = workflow_id
+        self._public_gcs = public_gcs
+        self._gcp_private_key = gcp_private_key
+        self._use_presigned_url_gcs = use_presigned_url_gcs
+        self._use_presigned_url_s3 = use_presigned_url_s3
+        self._duration_presigned_url_s3 = duration_presigned_url_s3
+        self._duration_presigned_url_gcs = duration_presigned_url_gcs
+        self._map_path_to_url = map_path_to_url
         self._ucsc_tracks = CrooHtmlReportUCSCTracks(
             out_dir=out_dir,
             workflow_id=workflow_id,
+            public_gcs=public_gcs,
+            gcp_private_key=gcp_private_key,
+            use_presigned_url_gcs=use_presigned_url_gcs,
+            use_presigned_url_s3=use_presigned_url_s3,
+            map_path_to_url=map_path_to_url,
             ucsc_genome_db=ucsc_genome_db,
             ucsc_genome_pos=ucsc_genome_pos)
         self._file_table = CrooHtmlReportFileTable(

--- a/croo/croo_html_report_file_table.py
+++ b/croo/croo_html_report_file_table.py
@@ -5,7 +5,7 @@
 """
 
 import os
-from caper.caper_uri import CaperURI, URI_LOCAL, URI_URL
+from autouri import AutoURI
 
 
 class CrooHtmlReportFileTable(object):
@@ -134,5 +134,5 @@ return false;">
             self._out_dir,
             CrooHtmlReportFileTable.FILETABLE_TSV.format(
                 workflow_id=self._workflow_id))
-        CaperURI(uri_filetable).write_str_to_file(contents)
+        AutoURI(uri_filetable).write(contents)
         return table_contents

--- a/croo/croo_html_report_task_graph.py
+++ b/croo/croo_html_report_task_graph.py
@@ -53,9 +53,9 @@ class CrooHtmlReportTaskGraph(object):
         if svg_contents is None:
             return ''
         else:
-            head = '<div id=\'task-graph\'><b>Task graph</b>\n'
-            tail = '</div><br>'
+            head = '<b>Task graph</b><div id=\'task-graph\'>\n'
             img = svg_contents
+            tail = '</div><br>'
             return head + img + tail
 
     def __make_svg(self):

--- a/croo/croo_html_report_task_graph.py
+++ b/croo/croo_html_report_task_graph.py
@@ -8,7 +8,7 @@ Author:
 import os
 from copy import deepcopy
 from base64 import b64encode
-from caper.caper_uri import CaperURI, URI_LOCAL, URI_URL
+from autouri import AutoURI
 
 
 class CrooHtmlReportTaskGraph(object):
@@ -26,6 +26,7 @@ class CrooHtmlReportTaskGraph(object):
                 A template dict that will be converted to a template dot file for graphviz
                 This dot file will be converted into SVG and finally be embedded in HTML
                 Refer to the function caper.dict_tool.dict_to_dot_str() for details
+                https://github.com/ENCODE-DCC/caper/blob/master/caper/dict_tool.py#L190
         """
         self._out_dir = out_dir
         self._workflow_id = workflow_id
@@ -97,7 +98,7 @@ class CrooHtmlReportTaskGraph(object):
             self._out_dir,
             CrooHtmlReportTaskGraph.TASK_GRAPH_DOT.format(
                 workflow_id=self._workflow_id))
-        CaperURI(uri_dot).write_str_to_file(dot_str)
+        AutoURI(uri_dot).write(dot_str)
 
         # save to SVG
         with open (svg, 'r') as fp:
@@ -106,7 +107,7 @@ class CrooHtmlReportTaskGraph(object):
             self._out_dir,
             CrooHtmlReportTaskGraph.TASK_GRAPH_SVG.format(
                 workflow_id=self._workflow_id))
-        CaperURI(uri_svg).write_str_to_file(svg_contents)
+        AutoURI(uri_svg).write(svg_contents)
 
         os.remove(tmp_dot)
         os.remove(svg)

--- a/croo/croo_html_report_task_graph.py
+++ b/croo/croo_html_report_task_graph.py
@@ -8,7 +8,10 @@ Author:
 import os
 from copy import deepcopy
 from base64 import b64encode
+from graphviz import Source
+from graphviz.backend import ExecutableNotFound
 from autouri import AutoURI
+from .croo import logger
 
 
 class CrooHtmlReportTaskGraph(object):
@@ -62,7 +65,6 @@ class CrooHtmlReportTaskGraph(object):
         """
         if not self._items:
             return None
-        from graphviz import Source
 
         # define call back functions for node format, href, subgraph
         def fnc_node_format(n):
@@ -90,8 +92,19 @@ class CrooHtmlReportTaskGraph(object):
             template=self._template_d)
         # temporary dot, svg from graphviz.Source.render
         tmp_dot = '_tmp_.dot'
-        svg = Source(dot_str, format='svg').render(
-            filename=tmp_dot)
+
+        try:
+            svg = Source(dot_str, format='svg').render(
+                filename=tmp_dot)
+        except (ExecutableNotFound, FileNotFoundError):
+            logger.info(
+                'Importing graphviz failed. Task graph will not be available. '
+                'Check if you have installed graphviz correctly so that '
+                '"dot" executable exists on your PATH. '
+                '"pip install graphviz" does not install such "dot". '
+                'Use apt or system-level installer instead. '
+                'e.g. sudo apt-get install graphviz.')
+            return None
 
         # save to DOT
         uri_dot = os.path.join(

--- a/croo/croo_html_report_tracks.py
+++ b/croo/croo_html_report_tracks.py
@@ -7,7 +7,7 @@ Author:
 
 import os
 import urllib.parse
-from caper.caper_uri import CaperURI
+from autouri import AutoURI
 
 
 class CrooHtmlReportUCSCTracks(object):
@@ -82,14 +82,14 @@ class CrooHtmlReportUCSCTracks(object):
             self._out_dir,
             CrooHtmlReportUCSCTracks.UCSC_TRACKS_TXT.format(
                 workflow_id=self._workflow_id))
-        CaperURI(uri_txt).write_str_to_file(txt)
+        AutoURI(uri_txt).write(txt)
 
         # save to URL
         uri_url = os.path.join(
             self._out_dir,
             CrooHtmlReportUCSCTracks.UCSC_TRACKS_URL.format(
                 workflow_id=self._workflow_id))
-        CaperURI(uri_url).write_str_to_file(url)
+        AutoURI(uri_url).write(url)
 
         return html
 

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['caper>=0.6.1', 'graphviz']
+    install_requires=['autouri>=0.1.1', 'graphviz']
 )


### PR DESCRIPTION
We have replaced old localization module (Caper's `CaperURI`) with a new one (Autouri's `AutoURI`).

- Deprecated parameters
  - `--http-user` and `--http-password`: Autouri automatically uses `~/.netrc` file for authentication of HTTP URLs. Use `~/.netrc` file.
  - `--use-gsutil-over-aws-s3`: Old module used `aws s3` CLI for S3 files and `gsutil` for GCS files. This parameter is no longer needed since new model uses Python interfaces instead of CLIs.

- Added parameters
  - `--verbose` (`-V`) and `--debug` (`-D`): Prints detailed logs. `verbose >= INFO`, `debug >= DEBUG`.
  - `--use-gsutil-for-s3`: This is different from the deprecated parameter `--use-gsutil-over-aws-s3`. Old loc module used `gsutil` CLI for file transfer between GCS (`gs://`) and any other. But new module optionally (controlled by this parameter) uses `gsutil` only for direct file transfer between GCS and S3 (`s3://`). If this flag is turned on `gsutil` will be used only for such direct file transfer.

- Bug fixes
  - `--tmp_dir` was not checked correctly (when it's on `$CWD`).
  - `--no-graph`: This will be removed, Croo will automatically check if `dot` executable exists on `$PATH`. This is a bit annoying since `pip install graphviz` does not install this important executable `dot`. Users can only get it with system-level installation command like `sudo apt-get install graphviz`.

- Important notice
  - UCSC browser web page no longer accepts long URL (where full track hub text is encoded in such URL). So instead, Croo makes another alternative link with a linked track hub txt file instead of a full track hub text. One issue is that this text file should be public. So this track hub txt file will be converted into public URL (according to parameters defined by users). e.g. being presigned on GCS.