### PR TITLE
use miniwdl to parse WDL

### DIFF
--- a/croo/croo.py
+++ b/croo/croo.py
@@ -11,7 +11,6 @@ import sys
 import logging
 import json
 import re
-import caper
 from autouri import AutoURI, AbsPath, GCSURI, S3URI, logger
 from .croo_args import parse_croo_arguments
 from .croo_html_report import CrooHtmlReport

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ],
-    install_requires=['autouri>=0.1.2.1', 'graphviz']
+    install_requires=['autouri>=0.1.2.1', 'graphviz', 'miniwdl']
 )


### PR DESCRIPTION
Move parameters (as comments) for Croo into WDL workflow's `meta` section. This `meta` section is optional and any string key / string value is allowed.

Example for ENCODE ATAC-Seq pipeline:
```
#CROO out_def https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json

workflow atac {
	meta {
		author: 'Jin wook Lee (leepc12@gmail.com) at ENCODE-DCC'
		description: 'ATAC-Seq/DNase-Seq pipeline'

		croo_out_def: 'https://storage.googleapis.com/encode-pipeline-output-definition/atac.croo.v4.json'
	}
}
```

`miniwdl`'s `WDL` package has `parse_document` function, which checks syntax of WDL but does not check imports. Use this function to get access to workflow's `meta` section.

Croo will still be able to parse comment-based parameters but it will be deprecated soon.