### PR TITLE
v0.5.2

### DIFF
--- a/croo/__init__.py
+++ b/croo/__init__.py
@@ -1,4 +1,4 @@
 from .croo import Croo
 
 __all__ = ['Croo']
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/croo/croo_html_report.py
+++ b/croo/croo_html_report.py
@@ -6,6 +6,7 @@ Author:
 """
 
 import os
+import tempfile
 import textwrap
 
 from autouri import AutoURI
@@ -18,9 +19,10 @@ from .croo_html_report_tracks import CrooHtmlReportUCSCTracks
 class CrooHtmlReport(object):
     HEAD = '@HEAD_CONTENTS'
     BODY = '@BODY_CONTENTS'
-    HTML = textwrap.dedent(
-        """
-        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
+    HTML = (
+        textwrap.dedent(
+            """
+        <!DOCTYPE html>
         <html lang="en">
           <head>
             <meta charset="utf-8">
@@ -30,7 +32,10 @@ class CrooHtmlReport(object):
           <body>{body_contents}</body>
         </html>
     """
-    ).format(head_contents=HEAD, body_contents=BODY)
+        )
+        .format(head_contents=HEAD, body_contents=BODY)
+        .lstrip()
+    )
     REPORT_HTML = 'croo.report.{workflow_id}.html'
 
     def __init__(
@@ -108,5 +113,11 @@ class CrooHtmlReport(object):
             self._out_dir,
             CrooHtmlReport.REPORT_HTML.format(workflow_id=self._workflow_id),
         )
-        AutoURI(uri_report).write(html)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            local_uri_report = os.path.join(
+                tmp_dir,
+                CrooHtmlReport.REPORT_HTML.format(workflow_id=self._workflow_id),
+            )
+            AutoURI(local_uri_report).write(html)
+            AutoURI(local_uri_report).cp(uri_report)
         return html

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='croo',
-    version='0.5.1',
+    version='0.5.2',
     scripts=['bin/croo'],
     python_requires='>=3.6',
     author='Jin Lee',


### PR DESCRIPTION
Bug fixes
- Graphviz-related error (`FileNotfoundError` for `.dot` or `.dot.svg`)
- Fix MIME type for HTML reports on GCS bucket.
  - Can click on HTML file on a GCS bucket and web browsers will correctly recognize it as a valid HTML.